### PR TITLE
rename strfile_compiler to fortune_compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This package provides the following features:
 
-- `:strfile_compiler` Mix compiler that builds a [strfile]-format index file
+- `:fortune_compiler` Mix compiler that builds a [strfile]-format index file
   based on your text file that contains a collection of quotes separated by a
   `%` line
 - Elixir functions that read a random fortune from compilied [strfile]s
@@ -74,7 +74,7 @@ Here are the steps to take:
 
 1. create `fortunes` directory in your Elixir project
 1. create a fortune text file or more that have no extension in your `fortunes` directory
-1. append `:strfile_compiler` to default Mix compilers in your `mix.exs`
+1. append `:fortune_compiler` to default Mix compilers in your `mix.exs`
 1. run `mix compile`
 
 **fortune file format**
@@ -104,13 +104,13 @@ The last string
 
 **setting up strfile compiler**
 
-Append `:strfile_compiler` to ` Mix.compilers/1` in your `mix.exs` as follows:
+Append `:fortune_compiler` to ` Mix.compilers/1` in your `mix.exs` as follows:
 
 ```elixir
   def project do
     [
       ...
-      compilers: Mix.compilers() ++ [:strfile_compiler],
+      compilers: Mix.compilers() ++ [:fortune_compiler],
       ...
     ]
   end
@@ -118,7 +118,7 @@ Append `:strfile_compiler` to ` Mix.compilers/1` in your `mix.exs` as follows:
 
 **compiling fortunes**
 
-When you run `mix compile`, `:strfile_compiler` will scan all the `fortunes`
+When you run `mix compile`, `:fortune_compiler` will scan all the `fortunes`
 directory in your project and its dependencies, then generate a `.dat` index
 data file corresponding to each fortune text file.
 
@@ -126,4 +126,3 @@ data file corresponding to each fortune text file.
 mix deps.get
 mix compile
 ```
-

--- a/example/library_a/mix.exs
+++ b/example/library_a/mix.exs
@@ -7,7 +7,7 @@ defmodule LibraryA.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
-      compilers: Mix.compilers() ++ [:strfile_compiler],
+      compilers: Mix.compilers() ++ [:fortune_compiler],
       deps: deps()
     ]
   end

--- a/example/library_b/mix.exs
+++ b/example/library_b/mix.exs
@@ -7,7 +7,7 @@ defmodule LibraryB.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
-      compilers: Mix.compilers() ++ [:strfile_compiler],
+      compilers: Mix.compilers() ++ [:fortune_compiler],
       deps: deps()
     ]
   end

--- a/example/my_app/mix.exs
+++ b/example/my_app/mix.exs
@@ -7,7 +7,7 @@ defmodule MyApp.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
-      compilers: Mix.compilers() ++ [:strfile_compiler],
+      compilers: Mix.compilers() ++ [:fortune_compiler],
       deps: deps()
     ]
   end

--- a/lib/mix/tasks/compile/fortune_compiler.ex
+++ b/lib/mix/tasks/compile/fortune_compiler.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Compile.StrfileCompiler do
+defmodule Mix.Tasks.Compile.FortuneCompiler do
   @moduledoc """
   Build STRFILE-format index files
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Fortune.MixProject do
       description: description(),
       package: package(),
       deps: deps(),
-      compilers: Mix.compilers() ++ [:strfile_compiler],
+      compilers: Mix.compilers() ++ [:fortune_compiler],
       dialyzer: dialyzer(),
       preferred_cli_env: %{
         docs: :docs,


### PR DESCRIPTION
This is to rename `:strfile_compiler` to `:fortune_compiler` because fortune sounds more familiar to human from the user perspective.

The internal strfile remain to be named strfile for consistency with Linux strfile.