### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fortune
 
 [![Hex version](https://img.shields.io/hexpm/v/fortune.svg "Hex version")](https://hex.pm/packages/fortune)
-[![API docs](https://img.shields.io/hexpm/v/fortune.svg?label=hexdocs "API docs")](https://hexdocs.pm/fortune/)
+[![API docs](https://img.shields.io/hexpm/v/fortune.svg?label=hexdocs "API docs")](https://fortune.hexdocs.pm/)
 [![CircleCI](https://circleci.com/gh/fhunleth/elixir-fortune.svg?style=svg)](https://circleci.com/gh/fhunleth/elixir-fortune)
 [![REUSE status](https://api.reuse.software/badge/github.com/fhunleth/elixir-fortune)](https://api.reuse.software/info/github.com/fhunleth/elixir-fortune)
 

--- a/example/library_a/README.md
+++ b/example/library_a/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/library_a>.
+be found at <https://library-a.hexdocs.pm>.
 

--- a/example/library_b/README.md
+++ b/example/library_b/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/library_b>.
+be found at <https://library-b.hexdocs.pm>.
 

--- a/example/my_app/README.md
+++ b/example/my_app/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/my_app>.
+be found at <https://my-app.hexdocs.pm>.
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://fortune.hexdocs.pm/): Status 404
❌ Verification failed for https://library-a.hexdocs.pm>: %Req.TransportError{reason: :nxdomain}
❌ Verification failed for https://library-b.hexdocs.pm>: %Req.TransportError{reason: :nxdomain}
❌ Verification failed for https://my-app.hexdocs.pm>: %Req.TransportError{reason: :nxdomain}
⚠️ Verification finished: 0 success, 4 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>